### PR TITLE
Primary key can't be text

### DIFF
--- a/alchemysession/sqlalchemy.py
+++ b/alchemysession/sqlalchemy.py
@@ -64,7 +64,7 @@ class AlchemySessionContainer:
             dc_id = Column(Integer, primary_key=True)
             server_address = Column(String(255))
             port = Column(Integer)
-            auth_key = Column(LargeBinary)
+            auth_key = Column(LargeBinary(255))
 
             def __str__(self):
                 return "Session('{}', {}, '{}', {}, {})".format(self.session_id, self.dc_id,
@@ -92,7 +92,7 @@ class AlchemySessionContainer:
             __tablename__ = '{prefix}sent_files'.format(prefix=prefix)
 
             session_id = Column(String(255), primary_key=True)
-            md5_digest = Column(LargeBinary, primary_key=True)
+            md5_digest = Column(LargeBinary(255), primary_key=True)
             file_size = Column(Integer, primary_key=True)
             type = Column(Integer, primary_key=True)
             id = Column(BigInteger)

--- a/alchemysession/sqlalchemy.py
+++ b/alchemysession/sqlalchemy.py
@@ -64,7 +64,7 @@ class AlchemySessionContainer:
             dc_id = Column(Integer, primary_key=True)
             server_address = Column(String(255))
             port = Column(Integer)
-            auth_key = Column(LargeBinary(255))
+            auth_key = Column(LargeBinary)
 
             def __str__(self):
                 return "Session('{}', {}, '{}', {}, {})".format(self.session_id, self.dc_id,
@@ -92,7 +92,7 @@ class AlchemySessionContainer:
             __tablename__ = '{prefix}sent_files'.format(prefix=prefix)
 
             session_id = Column(String(255), primary_key=True)
-            md5_digest = Column(LargeBinary(255), primary_key=True)
+            md5_digest = Column(LargeBinary)
             file_size = Column(Integer, primary_key=True)
             type = Column(Integer, primary_key=True)
             id = Column(BigInteger)


### PR DESCRIPTION
In order to address the following issue ...
```
sqlalchemy.exc.OperationalError: (_mysql_exceptions.OperationalError) (1170, "BLOB/TEXT column 'md5_digest' used in key specification without a key length") [SQL: '\nCREATE TABLE sent_files (\n\tsession_id VARCHAR(255) NOT NULL, \n\tmd5_digest BLOB NOT NULL, \n\tfile_size INTEGER NOT NULL, \n\ttype INTEGER NOT NULL, \n\tid BIGINT, \n\thash BIGINT, \n\tPRIMARY KEY (session_id, md5_digest, file_size, type)\n)\n\n'] (Background on this error at: http://sqlalche.me/e/e3q8)
```