### PR TITLE
Don't set UpdateState.date to a datetime object

### DIFF
--- a/alchemysession/sqlalchemy.py
+++ b/alchemysession/sqlalchemy.py
@@ -190,8 +190,8 @@ class AlchemySession(MemorySession):
     def get_update_state(self, entity_id: int) -> Optional[updates.State]:
         row = self.UpdateState.query.get((self.session_id, entity_id))
         if row:
-            row.date = datetime.datetime.utcfromtimestamp(row.date)
-            return updates.State(row.pts, row.qts, row.date, row.seq, row.unread_count)
+            date = datetime.datetime.utcfromtimestamp(row.date)
+            return updates.State(row.pts, row.qts, date, row.seq, row.unread_count)
         return None
 
     def set_update_state(self, entity_id: int, row: Any) -> None:


### PR DESCRIPTION
This causes SQLAlchemy to store a string on flush, crashing database
backends. Fixes #8.